### PR TITLE
Allow custom CheckString file buffers

### DIFF
--- a/Sources/FileCheck/CheckString.swift
+++ b/Sources/FileCheck/CheckString.swift
@@ -307,10 +307,16 @@ private func diagnoseFailedCheck(
   _ buffer: String
 ) {
   if let rtm = pattern.computeRegexToMatch(variableTable) {
-    if !pattern.fixedString.isEmpty {
+    if !pattern.fixedString.isEmpty && !rtm.isEmpty {
       diagnose(.error,
                at: loc,
                with: prefix + ": could not find '\(pattern.fixedString)' (with regex '\(rtm)') in input",
+        options: options
+      )
+    } else if !pattern.fixedString.isEmpty {
+      diagnose(.error,
+               at: loc,
+               with: prefix + ": could not find '\(pattern.fixedString)' in input",
         options: options
       )
     } else {

--- a/Tests/FileCheckTests/FileCheckSpec.swift
+++ b/Tests/FileCheckTests/FileCheckSpec.swift
@@ -3,6 +3,26 @@ import XCTest
 import Foundation
 
 class FileCheckSpec : XCTestCase {
+  func testCustomInputBuffer() {
+    XCTAssert(fileCheckOutput(of: .stdout, withPrefixes: ["CUSTOMEMPTYBUF-ERR"]) {
+      // CUSTOMEMPTYBUF-ERR: error: no check strings found with prefixes
+      // CUSTOMEMPTYBUF-ERR-NEXT: CUSTOMEMPTYBUF:
+      XCTAssertFalse(fileCheckOutput(of: .stdout, withPrefixes: ["CUSTOMEMPTYBUF"], against: .buffer(""), options: [.disableColors]) {
+        print("asdf")
+      })
+    })
+
+    XCTAssert(fileCheckOutput(of: .stdout, withPrefixes: ["CUSTOMBUF"], against: .buffer("""
+    // CUSTOMBUF: shi shi shi shi shi
+    // CUSTOMBUF-NEXT: asdf
+    """)) {
+      print("""
+            shi shi shi shi shi
+            asdf
+            """)
+    })
+  }
+
   func testWhitespace() {
     // Check that CHECK-NEXT without a space after the colon works.
     // Check that CHECK-NOT without a space after the colon works.
@@ -129,7 +149,7 @@ class FileCheckSpec : XCTestCase {
 
   func testNearestPattern() {
     XCTAssert(fileCheckOutput(of: .stdout, withPrefixes: ["CHECK-NEAREST-PATTERN-MSG"]) {
-      // CHECK-NEAREST-PATTERN-MSG: error: {{.*}}: could not find 'Once more into the beach' (with regex '') in input
+      // CHECK-NEAREST-PATTERN-MSG: error: {{.*}}: could not find 'Once more into the beach' in input
       // CHECK-NEAREST-PATTERN-MSG-NEXT: // {{.*}}: Once more into the beach
       // CHECK-NEAREST-PATTERN-MSG-NEXT: note: possible intended match here
       // CHECK-NEAREST-PATTERN-MSG-NEXT: Once more into the breach
@@ -189,6 +209,7 @@ class FileCheckSpec : XCTestCase {
 
   #if !os(macOS)
   static var allTests = testCase([
+    ("testCustomInputBuffer", testCustomInputBuffer),
     ("testWhitespace", testWhitespace),
     ("testSame", testSame),
     ("testCheckDAG", testCheckDAG),


### PR DESCRIPTION
In doing so, close a loophole around the parsing of check string buffers; if they were files, the implementation assumes that there's a trailing newline that we can always walk to.

This implementation has to work around SR-3258 by exposing a less-than-desirable `ExpressibleByStringLiteral` conformance that exists solely for the `#file` default initializer.