### PR TITLE
Disable diagnostics ANSI color for non-terminal

### DIFF
--- a/Sources/FileCheck/Diagnostics.swift
+++ b/Sources/FileCheck/Diagnostics.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 func diagnose(_ kind : DiagnosticKind, at loc : CheckLocation, with message : String, options: FileCheckOptions) {
-  let disableColors = options.contains(.disableColors)
+  let disableColors = options.contains(.disableColors) || isatty(fileno(stdout)) == 1
   if disableColors {
     print("\(kind): \(message)")
   } else {


### PR DESCRIPTION
If stdout is not a terminal device, don't color the output. This makes output in Vim quickfix buffer look much better since currently they are currently interleaved with ANSI code.

Alternative considered:

* Use [IsTTY](https://github.com/dduan/istty).
* Add a auto color option


![Screen Shot 2019-10-16 at 2 53 57 PM](https://user-images.githubusercontent.com/75067/66962020-cec4be80-f024-11e9-8c4f-0a08d5ee2b1a.png)
