### PR TITLE
Delete dependency on Rainbow

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,14 +13,13 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.0.1")),
-    .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.0.0"),
   ],
   targets: [
     .target(
       name: "FileCheck"),
     .target(
       name: "filecheck-tool",
-      dependencies: ["FileCheck", "SwiftToolsSupport", "Rainbow"]),
+      dependencies: ["FileCheck", "SwiftToolsSupport"]),
     .testTarget(
       name: "FileCheckTests",
       dependencies: ["FileCheck"]),

--- a/Sources/filecheck-tool/main.swift
+++ b/Sources/filecheck-tool/main.swift
@@ -2,7 +2,6 @@ import Foundation
 import TSCBasic
 import TSCUtility
 import FileCheck
-import Rainbow
 
 func run() -> Int {
   let cli = ArgumentParser(usage: "FileCheck", overview: "")
@@ -73,7 +72,6 @@ func run() -> Int {
     cli.printUsage(on: stderrStream)
     return -1
   }
-  Rainbow.enabled = !options.contains(.disableColors)
 
   let fileHandle: FileHandle
   if let input = results.get(inputFile) {


### PR DESCRIPTION
Turns out it's not really used for anything. Delete it for now.