### PR TITLE
Fix TTY colors

### DIFF
--- a/Sources/FileCheck/Diagnostics.swift
+++ b/Sources/FileCheck/Diagnostics.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 func diagnose(_ kind : DiagnosticKind, at loc : CheckLocation, with message : String, options: FileCheckOptions) {
-  let disableColors = options.contains(.disableColors) || isatty(fileno(stdout)) == 1
+  let disableColors = options.contains(.disableColors) || isatty(fileno(stdout)) != 1
   if disableColors {
     print("\(kind): \(message)")
   } else {


### PR DESCRIPTION
The change from https://github.com/llvm-swift/FileCheck/pull/13 actually
disabled coloring when output device is a TTY device.

Excerpt from BSD manual for `isatty`:

```
RETURN VALUES
     The isatty() function returns 1 if fd refers to a terminal type
     device; otherwise, it returns 0 and may set errno to indicate the
     error.
```

Double negative is hard. 🤦‍♀️

Anyways.