### PR TITLE
Eliminate compiler warning

### DIFF
--- a/Sources/FileCheck/FileCheck.swift
+++ b/Sources/FileCheck/FileCheck.swift
@@ -567,7 +567,7 @@ private func check(
     if options.contains(.scopedVariables) {
       var localVariables = [String]()
       localVariables.reserveCapacity(16)
-      for (k, v) in variableTable where !k.hasPrefix("$") {
+      for k in variableTable.keys where !k.hasPrefix("$") {
         localVariables.append(k)
       }
 


### PR DESCRIPTION
Swift 5.2 surfaces this unused variable `v` during compilation. Let's
get rid of the warning.