### PR TITLE
Migrate to Swift ArgumentParser

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - "11.1"
-          - "11.2"
+          - "11.7"
+          - "12.2"
         action:
           - build
           - test
@@ -27,11 +27,12 @@ jobs:
     strategy:
       matrix:
         swift:
-          - 5.1.1
-          - 5.1.2
+          - 5.2.5
+          - 5.3.1
         ubuntu:
-          - xenial
           - bionic
+          - xenial
+          - focal
         action:
           - build
           - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
   - os: osx
     language: objective-c
-    osx_image: xcode11.2
+    osx_image: xcode12.2
     script:
     - swift test
   - os: linux
@@ -15,9 +15,9 @@ matrix:
     env:
     before_install:
     - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
-    - wget https://swift.org/builds/swift-5.1-release/ubuntu1404/swift-5.1-RELEASE/swift-5.1-RELEASE-ubuntu14.04.tar.gz
-    - tar xzf swift-5.1-RELEASE-ubuntu14.04.tar.gz
-    - export PATH=${PWD}/swift-5.1-RELEASE-ubuntu14.04/usr/bin:"${PATH}"
+    - wget https://swift.org/builds/swift-5.3.1-release/ubuntu20.04/swift-5.3.1-RELEASE/swift-5.3.1-RELEASE-ubuntu20.04.tar.gz
+    - tar xzf swift-5.3.1-RELEASE-ubuntu20.04.tar.gz
+    - export PATH=${PWD}/swift-5.3.1-RELEASE-ubuntu20.04/usr/bin:"${PATH}"
     script:
     - swift test
 notifications:

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
       targets: ["FileCheck"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.0.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.1"),
     .package(url: "https://github.com/mxcl/Chalk.git", from: "0.1.0"),
   ],
   targets: [
@@ -21,7 +21,7 @@ let package = Package(
       dependencies: ["Chalk"]),
     .target(
       name: "filecheck-tool",
-      dependencies: ["FileCheck", "SwiftToolsSupport"]),
+      dependencies: ["FileCheck", "ArgumentParser"]),
     .testTarget(
       name: "FileCheckTests",
       dependencies: ["FileCheck"]),


### PR DESCRIPTION
… replacing `swift-tools-support-core` as the library responsible for the executable's UI.

I ran the following Bash script as a sanity check:

```bash
#!/bin/bash

swift build
echo '// CHECK: hello' > /tmp/test.swift
echo 'print("hello")' >> /tmp/test.swift
swift /tmp/test.swift | .build/debug/filecheck /tmp/test.swift


echo '// CHECK: hello' > /tmp/test.swift
echo 'print("world")' >> /tmp/test.swift
swift /tmp/test.swift | .build/debug/filecheck /tmp/test.swift
```

output:

```
error: CHECK: could not find 'hello' in input
// CHECK: hello
note: scanning from here
world

note: possible intended match here
world
```