### PR TITLE
Upgrade Argument Parser to 1.1.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,11 +26,9 @@ jobs:
     strategy:
       matrix:
         swift:
-          - 5.2.5
           - 5.5.3
         ubuntu:
           - bionic
-          - xenial
           - focal
         action:
           - build

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,10 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 
 import PackageDescription
 
 let package = Package(
   name: "FileCheck",
+  platforms: [.macOS(.v10_15)],
   products: [
     .executable(name: "filecheck",
                 targets: ["filecheck-tool"]),
@@ -12,7 +13,7 @@ let package = Package(
       targets: ["FileCheck"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.1"),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.0"),
     .package(url: "https://github.com/mxcl/Chalk.git", from: "0.1.0"),
   ],
   targets: [


### PR DESCRIPTION
Use the latest argument parser with the maximum backward compatility in
the package manifest.